### PR TITLE
Add methods Values() & Read(). Add Current. Add IDisposable()

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,248 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_method = true
+dotnet_style_qualification_for_property = true
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_collection_expression = when_types_loosely_match
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = false
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+csharp_style_prefer_readonly_struct = true
+csharp_style_prefer_readonly_struct_member = true
+
+# Code-block preferences
+csharp_prefer_braces = when_multiline:suggestion
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:silent
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+[*.{cs,vb}]
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_qualification_for_field = true:suggestion
+dotnet_style_qualification_for_property = true:suggestion
+dotnet_style_qualification_for_method = true:suggestion
+dotnet_style_qualification_for_event = true:suggestion

--- a/Example/ConsoleJsonSample.csproj
+++ b/Example/ConsoleJsonSample.csproj
@@ -13,10 +13,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\JsonExtensions\JsonExtensions.csproj" />
 	</ItemGroup>
 

--- a/Example/ConsoleJsonSample.csproj
+++ b/Example/ConsoleJsonSample.csproj
@@ -1,23 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
-  </ItemGroup>
+		<TargetFrameworkNetCore>netcoreapp3.1</TargetFrameworkNetCore>
+		<TargetFrameworkNet6>net6.0</TargetFrameworkNet6>
+		<TargetFrameworkNet8>net8.0</TargetFrameworkNet8>
+		<TargetFrameworks>$(TargetFrameworkNetCore);$(TargetFrameworkNet6);$(TargetFrameworkNet8)</TargetFrameworks>
+		<LangVersion>12.0</LangVersion>
 
-  <ItemGroup>
-    <ProjectReference Include="..\JsonExtensions\JsonExtensions.csproj" />
-  </ItemGroup>
+		<OutputType>Exe</OutputType>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Update="Address.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\JsonExtensions\JsonExtensions.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="Address.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -10,21 +10,10 @@ namespace ConsoleJsonSample
         // to be sure we can call the JsonReader.Read() method from an async scope
         static async Task Main(string[] args)
         {
-            var jsonReader = new JsonReader(GetSmallMemoryStream(), 1024); // test 10 to see buffer increase in debug console
+            var jsonReader = new JsonReader(GetMemoryStream(), 1024); // test 10 to see buffer increase in debug console
 
-            foreach (var prop in jsonReader.Values())
-            {
-                if (prop.TokenType == JsonTokenType.StartObject || prop.TokenType == JsonTokenType.StartArray || prop.TokenType == JsonTokenType.EndObject || prop.TokenType == JsonTokenType.EndArray)
-                    Console.WriteLine($"- ({prop.TokenType})");
-                else if (prop.TokenType == JsonTokenType.PropertyName)
-                    Console.WriteLine($"Property: {prop.Name}");
-                else
-                    Console.WriteLine($"Value: {prop.Value}");
-            }
-
-            //while (jsonReader.Read())
+            //foreach (var prop in jsonReader.Values())
             //{
-            //    var prop = jsonReader.Current;
             //    if (prop.TokenType == JsonTokenType.StartObject || prop.TokenType == JsonTokenType.StartArray || prop.TokenType == JsonTokenType.EndObject || prop.TokenType == JsonTokenType.EndArray)
             //        Console.WriteLine($"- ({prop.TokenType})");
             //    else if (prop.TokenType == JsonTokenType.PropertyName)
@@ -32,6 +21,23 @@ namespace ConsoleJsonSample
             //    else
             //        Console.WriteLine($"Value: {prop.Value}");
             //}
+
+            while (jsonReader.Read())
+            {
+
+                if (jsonReader.Current.TokenType == JsonTokenType.PropertyName)
+                {
+                    var prop = jsonReader.Current.Name;
+                    jsonReader.Skip();
+                    var value = jsonReader.Current.Value;
+                    Console.WriteLine($"{prop}: {value}");
+                }
+            }
+
+            while (jsonReader.Read())
+            {
+                Console.WriteLine(jsonReader);
+            }
         }
 
 

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -10,9 +10,9 @@ namespace ConsoleJsonSample
         // to be sure we can call the JsonReader.Read() method from an async scope
         static async Task Main(string[] args)
         {
-            var jsonReader = new JsonReader(GetFileStream(), 1024); // test 10 to see buffer increase in debug console
+            var jsonReader = new JsonReader(GetSmallMemoryStream(), 1024); // test 10 to see buffer increase in debug console
 
-            foreach (var prop in jsonReader.Read())
+            foreach (var prop in jsonReader.Values())
             {
                 if (prop.TokenType == JsonTokenType.StartObject || prop.TokenType == JsonTokenType.StartArray || prop.TokenType == JsonTokenType.EndObject || prop.TokenType == JsonTokenType.EndArray)
                     Console.WriteLine($"- ({prop.TokenType})");
@@ -21,6 +21,17 @@ namespace ConsoleJsonSample
                 else
                     Console.WriteLine($"Value: {prop.Value}");
             }
+
+            //while (jsonReader.Read())
+            //{
+            //    var prop = jsonReader.Current;
+            //    if (prop.TokenType == JsonTokenType.StartObject || prop.TokenType == JsonTokenType.StartArray || prop.TokenType == JsonTokenType.EndObject || prop.TokenType == JsonTokenType.EndArray)
+            //        Console.WriteLine($"- ({prop.TokenType})");
+            //    else if (prop.TokenType == JsonTokenType.PropertyName)
+            //        Console.WriteLine($"Property: {prop.Name}");
+            //    else
+            //        Console.WriteLine($"Value: {prop.Value}");
+            //}
         }
 
 
@@ -29,6 +40,14 @@ namespace ConsoleJsonSample
             return new FileStream("Address.json", FileMode.Open);
         }
 
+
+        static MemoryStream GetSmallMemoryStream()
+        {
+            var jsonSmallArray = """[12]""";
+
+            byte[] bytes = Encoding.UTF8.GetBytes(jsonSmallArray);
+            return new MemoryStream(bytes);
+        }
         static MemoryStream GetMemoryStream()
         {
             var jsonString = @"[{

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Data;
+using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using JsonExtensions;
 
@@ -10,34 +12,34 @@ namespace ConsoleJsonSample
         // to be sure we can call the JsonReader.Read() method from an async scope
         static async Task Main(string[] args)
         {
-            var jsonReader = new JsonReader(GetMemoryStream(), 1024); // test 10 to see buffer increase in debug console
-
-            //foreach (var prop in jsonReader.Values())
-            //{
-            //    if (prop.TokenType == JsonTokenType.StartObject || prop.TokenType == JsonTokenType.StartArray || prop.TokenType == JsonTokenType.EndObject || prop.TokenType == JsonTokenType.EndArray)
-            //        Console.WriteLine($"- ({prop.TokenType})");
-            //    else if (prop.TokenType == JsonTokenType.PropertyName)
-            //        Console.WriteLine($"Property: {prop.Name}");
-            //    else
-            //        Console.WriteLine($"Value: {prop.Value}");
-            //}
+            var jsonReader = new JsonReader(GetFileStream()); // test 10 to see buffer increase in debug console
 
             while (jsonReader.Read())
             {
+                // write numbers of space for the current depth
+                var indent = new string(' ', jsonReader.Depth * 2);
 
-                if (jsonReader.Current.TokenType == JsonTokenType.PropertyName)
-                {
-                    var prop = jsonReader.Current.Name;
-                    jsonReader.Skip();
-                    var value = jsonReader.Current.Value;
-                    Console.WriteLine($"{prop}: {value}");
-                }
+                if (jsonReader.TokenType == JsonTokenType.StartObject)
+                    Console.WriteLine($"{indent}{{");
+                else if (jsonReader.TokenType == JsonTokenType.EndObject)
+                    Console.WriteLine($"{indent}}}");
+                else if (jsonReader.TokenType == JsonTokenType.StartArray)
+                    Console.WriteLine($"{indent}[");
+                else if (jsonReader.TokenType == JsonTokenType.EndArray)
+                    Console.WriteLine($"{indent}]");
+                else if (jsonReader.TokenType == JsonTokenType.PropertyName)
+                    Console.Write($"{indent}{jsonReader.GetString()}:");
+                else if (jsonReader.TokenType == JsonTokenType.String)
+                    Console.WriteLine(jsonReader.GetString());
+                else if (jsonReader.TokenType == JsonTokenType.Number)
+                    Console.WriteLine(jsonReader.GetDouble());
+                else if (jsonReader.TokenType == JsonTokenType.True || jsonReader.TokenType == JsonTokenType.False)
+                    Console.WriteLine(jsonReader.GetBoolean());
+                else
+                    Console.WriteLine();
+
             }
 
-            while (jsonReader.Read())
-            {
-                Console.WriteLine(jsonReader);
-            }
         }
 
 

--- a/JsonExstensions.sln
+++ b/JsonExstensions.sln
@@ -9,10 +9,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonExtensions", "JsonExten
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B80FC46E-1517-414C-A4BB-E634B5D55DCA}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{13B5130D-7D8F-4D9B-B5A8-0256F798CEE2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{13B5130D-7D8F-4D9B-B5A8-0256F798CEE2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/JsonExtensions/JsonExtensions.csproj
+++ b/JsonExtensions/JsonExtensions.csproj
@@ -1,9 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+
+		<TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
+		<TargetFrameworkNet6>net6.0</TargetFrameworkNet6>
+		<TargetFrameworkNet8>net8.0</TargetFrameworkNet8>
+
+		<TargetFrameworks>$(TargetFrameworkNetStandard);$(TargetFrameworkNet6);$(TargetFrameworkNet8)</TargetFrameworks>
+		<LangVersion>12.0</LangVersion>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup  Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetStandard)' ">
+	  <PackageReference Include="System.Text.Json" Version="8.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -130,7 +130,6 @@ namespace JsonExtensions
                     this.tokensFound++;
                     this.hasMore = true;
                     this.Current = GetValue(ref reader);
-                    Debug.WriteLine(this);
                     return true;
                 }
 

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -1,12 +1,20 @@
-﻿using System.Text;
+﻿using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 
 namespace JsonExtensions
 {
 
     public class JsonReader : IDisposable
     {
+
+        // encoding used to convert bytes to string
+        private static readonly UTF8Encoding utf8Encoding = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
         /// <summary>
         /// Stream to read
         /// </summary>
@@ -23,7 +31,7 @@ namespace JsonExtensions
         /// <param name="stream">Stream to read</param>
         /// <param name="bufferSize">buffer size. will adapt if needed</param>
         /// <exception cref="Exception">If stream is not readable</exception>
-        public JsonReader(Stream stream, int bufferSize = 1024, JsonReaderOptions jsonReaderOptions = default)
+        public JsonReader(Stream stream, JsonReaderOptions jsonReaderOptions = default, int bufferSize = 1024)
         {
             this.Stream = stream;
             this.bufferSize = bufferSize;
@@ -57,6 +65,7 @@ namespace JsonExtensions
 
         // state object used internally by Utf8JsonReader
         private JsonReaderState currentState;
+        private JsonReaderState prevState;
 
         // bytes consumed by Utf8JsonReader each time it reads a token
         private int bytesConsumed;
@@ -67,10 +76,27 @@ namespace JsonExtensions
         private bool disposedValue;
 
 
+        ///// <summary>
+        ///// Current value
+        ///// </summary>
+        //public JsonReaderValue Current { get; private set; }
+
         /// <summary>
-        /// Current value
+        /// Gets the token value. Can be a value or a property name
         /// </summary>
-        public JsonReaderValue Current { get; private set; }
+        public ReadOnlyMemory<byte> Value { get; private set; }
+
+        /// <summary>
+        /// Gets the token type
+        /// </summary>
+        public JsonTokenType TokenType { get; private set; } = JsonTokenType.None;
+
+        /// <summary>
+        /// Gets the current depth
+        /// </summary>
+        public int Depth { get; private set; } = 0;
+
+
 
         /// <summary>
         /// Read the next value. Can be any TokenType
@@ -121,10 +147,11 @@ namespace JsonExtensions
                     this.bytesConsumed = (int)reader.BytesConsumed;
                     this.tokensFound++;
                     this.hasMore = true;
-                    this.Current = GetValue(ref reader);
+                    this.TokenType = reader.TokenType;
+                    this.Depth = reader.CurrentDepth;
+                    this.Value = new ReadOnlyMemory<byte>(reader.ValueSpan.ToArray());
                     return true;
                 }
-
 
                 // if we don't have any more bytes and in final block, we can exit
                 if (this.dataLen <= 0 && this.isFinalBlock)
@@ -155,9 +182,7 @@ namespace JsonExtensions
                 {
                     foundToken = false;
                 }
-
             }
-
             return false;
         }
 
@@ -169,19 +194,33 @@ namespace JsonExtensions
         {
             while (this.Read())
             {
-                yield return this.Current;
+                JsonReaderValue jsonReaderValue = new() { TokenType = this.TokenType, Depth = this.Depth };
+                if (this.TokenType == JsonTokenType.PropertyName)
+                    jsonReaderValue.Value = JsonValue.Create(this.GetString());
+                else if (this.TokenType == JsonTokenType.Null || this.TokenType == JsonTokenType.None)
+                    jsonReaderValue.Value = null;
+                else if (this.TokenType == JsonTokenType.String)
+                    jsonReaderValue.Value = JsonValue.Create(this.GetString());
+                else if (this.TokenType == JsonTokenType.False || this.TokenType == JsonTokenType.True)
+                    jsonReaderValue.Value = JsonValue.Create(this.GetBoolean());
+                else if (this.TokenType == JsonTokenType.Number)
+                    jsonReaderValue.Value = JsonValue.Create(this.GetDouble());
+
+                yield return jsonReaderValue;
             }
         }
 
-
+        /// <summary>
+        /// Skips the children of the current token.
+        /// </summary>
         public bool Skip()
         {
-            if (this.Current.TokenType == JsonTokenType.PropertyName)
+            if (this.TokenType == JsonTokenType.PropertyName)
                 return this.Read();
 
-            if (this.Current.TokenType == JsonTokenType.StartObject || this.Current.TokenType == JsonTokenType.StartArray)
+            if (this.TokenType == JsonTokenType.StartObject || this.TokenType == JsonTokenType.StartArray)
             {
-                int depth = this.Current.Depth;
+                int depth = this.Depth;
                 do
                 {
                     bool hasRead = this.Read();
@@ -189,34 +228,13 @@ namespace JsonExtensions
                     if (!hasRead)
                         return false;
                 }
-                while (depth < this.Current.Depth);
+                while (depth < this.Depth);
 
                 return true;
             }
             return false;
         }
 
-        private static JsonReaderValue GetValue(ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray or JsonTokenType.EndObject or JsonTokenType.EndArray)
-                return new JsonReaderValue { TokenType = reader.TokenType, Depth = reader.CurrentDepth };
-
-            if (reader.TokenType == JsonTokenType.PropertyName)
-                return new JsonReaderValue { TokenType = reader.TokenType, Name = reader.GetString(), Depth = reader.CurrentDepth };
-
-            JsonValue? propertyValue = null;
-            if (reader.TokenType == JsonTokenType.Null || reader.TokenType == JsonTokenType.None)
-                propertyValue = null;
-            else if (reader.TokenType == JsonTokenType.String)
-                propertyValue = JsonValue.Create(reader.GetString());
-            else if (reader.TokenType == JsonTokenType.False || reader.TokenType == JsonTokenType.True)
-                propertyValue = JsonValue.Create(reader.GetBoolean());
-            else if (reader.TokenType == JsonTokenType.Number)
-                propertyValue = JsonValue.Create(reader.GetDouble());
-
-            return new JsonReaderValue { Value = propertyValue, TokenType = reader.TokenType, Depth = reader.CurrentDepth };
-
-        }
 
         protected virtual void Dispose(bool disposing)
         {
@@ -248,17 +266,224 @@ namespace JsonExtensions
             GC.SuppressFinalize(this);
         }
 
-        public override string ToString()
+
+        public string? ReadAsString()
         {
-            return this.Current.ToString();
+            this.Read();
+            return this.GetString();
         }
+        public string? GetString()
+        {
+            if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
+                return null;
+
+            var str = utf8Encoding.GetString(this.Value.ToArray());
+
+            return Regex.Unescape(str);
+        }
+        public string? ReadAsEscapedString()
+        {
+            this.Read();
+            return this.GetEscapedString();
+        }
+        public string? GetEscapedString()
+        {
+            if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
+                return null;
+
+            var str = utf8Encoding.GetString(this.Value.ToArray());
+
+            return str;
+        }
+        public Guid? ReadAsGuid()
+        {
+            this.Read();
+            return this.GetGuid();
+        }
+        public Guid? GetGuid()
+        {
+            if (this.TokenType != JsonTokenType.String)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out Guid tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse double");
+        }
+        public TimeSpan? ReadAsTimeSpan()
+        {
+            this.Read();
+            return this.GetTimeSpan();
+        }
+        public TimeSpan? GetTimeSpan()
+        {
+            if (this.TokenType != JsonTokenType.String)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out TimeSpan tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse TimeSpan");
+        }
+        public DateTimeOffset? ReadAsDateTimeOffset()
+        {
+            this.Read();
+            return this.GetDateTimeOffset();
+        }
+        public DateTimeOffset? GetDateTimeOffset()
+        {
+            if (this.TokenType != JsonTokenType.String)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out DateTimeOffset tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse DateTimeOffset");
+        }
+        public DateTime? ReadAsDateTime()
+        {
+            this.Read();
+            return this.GetDateTime();
+        }
+        public DateTime? GetDateTime()
+        {
+            if (this.TokenType != JsonTokenType.String)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out DateTime tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse GetDateTime");
+        }
+        public double? ReadAsDouble()
+        {
+            this.Read();
+            return this.GetDouble();
+        }
+        public double? GetDouble()
+        {
+            if (this.TokenType != JsonTokenType.Number)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out double tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse double");
+        }
+        public decimal? ReadAsDecimal()
+        {
+            this.Read();
+            return this.GetDecimal();
+        }
+        public decimal? GetDecimal()
+        {
+            if (this.TokenType != JsonTokenType.Number)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out decimal tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse decimal");
+        }
+        public float? ReadAsSingle()
+        {
+            this.Read();
+            return this.GetSingle();
+        }
+        public float? GetSingle()
+        {
+            if (this.TokenType != JsonTokenType.Number)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out float tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse float");
+        }
+        public long? ReadAsInt64()
+        {
+            this.Read();
+            return this.GetInt64();
+        }
+        public long? GetInt64()
+        {
+            if (this.TokenType != JsonTokenType.Number)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out long tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse long");
+        }
+        public int? ReadAsInt32()
+        {
+            this.Read();
+            return this.GetInt32();
+        }
+        public int? GetInt32()
+        {
+            if (this.TokenType != JsonTokenType.Number)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out int tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse int");
+        }
+        public short? ReadAsInt16()
+        {
+            this.Read();
+            return this.GetInt16();
+        }
+        public short? GetInt16()
+        {
+            if (this.TokenType != JsonTokenType.Number)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out short tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse short");
+        }
+        public byte? ReadAsByte()
+        {
+            this.Read();
+            return this.GetByte();
+        }
+        public byte? GetByte()
+        {
+            if (this.TokenType != JsonTokenType.Number)
+                return null;
+
+            if (Utf8Parser.TryParse(this.Value.Span, out byte tmp, out int bytesConsumed) && this.Value.Span.Length == bytesConsumed)
+                return tmp;
+
+            throw new FormatException("Can't parse byte");
+        }
+        public bool? ReadAsBoolean()
+        {
+            this.Read();
+            return this.GetBoolean();
+        }
+        public bool? GetBoolean()
+        {
+            if (this.TokenType == JsonTokenType.True)
+                return true;
+            else if (this.TokenType == JsonTokenType.False)
+                return false;
+            else
+                return null;
+        }
+
+        //public byte[] GetBytesFromBase64()
+        //{
+        //    return null;
+        //}
 
     }
 
     public struct JsonReaderValue
     {
-
-        public string? Name { get; set; } = string.Empty;
         public JsonValue? Value { get; set; }
         public JsonTokenType TokenType { get; set; } = JsonTokenType.None;
         public int Depth { get; set; } = 0;
@@ -270,7 +495,7 @@ namespace JsonExtensions
             var sb = new StringBuilder($"Type: {this.TokenType} - Depth: {this.Depth}");
 
             if (this.TokenType == JsonTokenType.PropertyName)
-                sb.Append($" - Property: {this.Name}");
+                sb.Append($" - Property: {this.Value}");
 
             if (this.Value != null)
                 sb.Append($" - Value: {this.Value}");

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection.PortableExecutable;
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization.Metadata;
-using System.Threading.Tasks;
 
 namespace JsonExtensions
 {
@@ -105,7 +97,7 @@ namespace JsonExtensions
                     int todo = this.buffer.Length - this.dataLen;
                     int done = this.Stream.Read(this.buffer, this.dataLen, todo);
                     this.dataLen += done;
-                    this.isFinalBlock = (done < todo);
+                    this.isFinalBlock = done < todo;
                     this.bytesConsumed = 0;
                     this.tokensFound = 0;
                 }
@@ -185,7 +177,7 @@ namespace JsonExtensions
         public bool Skip()
         {
             if (this.Current.TokenType == JsonTokenType.PropertyName)
-                return (this.Read());
+                return this.Read();
 
             if (this.Current.TokenType == JsonTokenType.StartObject || this.Current.TokenType == JsonTokenType.StartArray)
             {
@@ -228,27 +220,31 @@ namespace JsonExtensions
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!this.disposedValue)
             {
                 if (disposing)
                 {
                     if (this.buffer != null)
                     {
+#if NET6_0_OR_GREATER
                         Array.Clear(this.buffer);
+#else
+                        Array.Clear(this.buffer, 0, this.buffer.Length);
+#endif
                         this.buffer = null;
                     }
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
                 // TODO: set large fields to null
-                disposedValue = true;
+                this.disposedValue = true;
             }
         }
 
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
+            this.Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
 
@@ -261,8 +257,8 @@ namespace JsonExtensions
 
     public struct JsonReaderValue
     {
-        
-        public string Name { get; set; } = string.Empty;
+
+        public string? Name { get; set; } = string.Empty;
         public JsonValue? Value { get; set; }
         public JsonTokenType TokenType { get; set; } = JsonTokenType.None;
         public int Depth { get; set; } = 0;

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -78,7 +78,7 @@ namespace JsonExtensions
         /// <summary>
         /// Current value
         /// </summary>
-        public JsonReaderValue? Current { get; private set; }
+        public JsonReaderValue Current { get; private set; }
 
         /// <summary>
         /// Read the next value. Can be any TokenType
@@ -178,17 +178,13 @@ namespace JsonExtensions
         {
             while (this.Read())
             {
-                if (this.Current != null)
-                    yield return this.Current;
+                yield return this.Current;
             }
         }
 
 
         public bool Skip()
         {
-            if (this.Current == null)
-                return false;
-
             if (this.Current.TokenType == JsonTokenType.PropertyName)
                 return (this.Read());
 
@@ -242,7 +238,6 @@ namespace JsonExtensions
                         Array.Clear(this.buffer);
                         this.buffer = null;
                     }
-                    this.Current = null;
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
@@ -260,21 +255,20 @@ namespace JsonExtensions
 
         public override string ToString()
         {
-
-            if (this.Current == null)
-                return base.ToString();
-
             return this.Current.ToString();
         }
 
     }
 
-    public class JsonReaderValue
+    public struct JsonReaderValue
     {
-        public string? Name { get; set; }
+        
+        public string Name { get; set; } = string.Empty;
         public JsonValue? Value { get; set; }
-        public JsonTokenType TokenType { get; set; }
-        public int Depth { get; set; }
+        public JsonTokenType TokenType { get; set; } = JsonTokenType.None;
+        public int Depth { get; set; } = 0;
+
+        public JsonReaderValue() { }
 
         public override string ToString()
         {

--- a/Tests/JsonReaderTests.cs
+++ b/Tests/JsonReaderTests.cs
@@ -78,7 +78,7 @@ namespace Tests
 
             Assert.ThrowsAny<JsonException>(() =>
             {
-                foreach(var v in jsonReader.Read())
+                foreach(var v in jsonReader.Values())
                 {
                     output.WriteLine($"{v.TokenType}");
                 }
@@ -93,7 +93,7 @@ namespace Tests
 
             Assert.ThrowsAny<JsonException>(() =>
             {
-                foreach(var v in jsonReader.Read())
+                foreach(var v in jsonReader.Values())
                 {
                     output.WriteLine($"{v.TokenType}");
                 }
@@ -108,7 +108,7 @@ namespace Tests
 
             var x = Assert.ThrowsAny<JsonException>(() =>
             {
-                foreach(var v in jsonReader.Read())
+                foreach(var v in jsonReader.Values())
                 {
                     output.WriteLine($"{v.TokenType}");
                 }
@@ -123,7 +123,7 @@ namespace Tests
 
             Assert.ThrowsAny<JsonException>(() =>
             {
-                foreach(var v in jsonReader.Read())
+                foreach(var v in jsonReader.Values())
                 {
                     output.WriteLine($"{v.TokenType}");
                 }
@@ -135,7 +135,7 @@ namespace Tests
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonSmallObject));
             var jsonReader = new JsonReader(stream, 10);
-            var tokens = jsonReader.Read().Select(x => x.TokenType).ToList();
+            var tokens = jsonReader.Values().Select(x => x.TokenType).ToList();
 
             Assert.Equal([
                 JsonTokenType.StartObject,
@@ -154,7 +154,7 @@ namespace Tests
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonSmallArray));
             var jsonReader = new JsonReader(stream, 10);
-            var tokens = jsonReader.Read().Select(x => x.TokenType).ToList();
+            var tokens = jsonReader.Values().Select(x => x.TokenType).ToList();
 
             Assert.Equal([
                 JsonTokenType.StartArray,
@@ -171,7 +171,7 @@ namespace Tests
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
             var jsonReader = new JsonReader(stream, 10);
-            var tokens = jsonReader.Read().Where(x => x.TokenType == JsonTokenType.String).Select(v => v.Value.ToString()).ToList();
+            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.String).Select(v => v.Value.ToString()).ToList();
 
             Assert.Equal(["2019-08-01T00:00:00-07:00", "Hot", "2019-08-01T00:00:00-07:00", "Hot"], tokens);
         }
@@ -181,7 +181,7 @@ namespace Tests
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
             var jsonReader = new JsonReader(stream, 10);
-            var tokens = jsonReader.Read().Where(x => x.TokenType == JsonTokenType.Number).Select(v => v.Value.Deserialize<double>()).ToList();
+            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.Number).Select(v => v.Value.Deserialize<double>()).ToList();
 
             Assert.Equal([25, 20, -10.5, 60, 20, 25, 20, -10, 60, 20], tokens);
         }
@@ -191,7 +191,7 @@ namespace Tests
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
             var jsonReader = new JsonReader(stream, 10);
-            var tokens = jsonReader.Read().Where(x => x.TokenType == JsonTokenType.False || x.TokenType == JsonTokenType.True).Select(v => v.Value.Deserialize<bool>()).ToList();
+            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.False || x.TokenType == JsonTokenType.True).Select(v => v.Value.Deserialize<bool>()).ToList();
 
             Assert.Equal([true, false], tokens);
         }

--- a/Tests/JsonReader_Values_Tests.cs
+++ b/Tests/JsonReader_Values_Tests.cs
@@ -74,7 +74,7 @@ namespace Tests
         {
             var largeGapJson = $"{{ \"a\": {new String(' ', 2 * 1024 * 1024)}10 }}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(largeGapJson));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
 
             Assert.ThrowsAny<JsonException>(() =>
             {
@@ -89,7 +89,7 @@ namespace Tests
         public void InvalidJson_ShouldThrow()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonInvalid));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
 
             Assert.ThrowsAny<JsonException>(() =>
             {
@@ -104,7 +104,7 @@ namespace Tests
         public void UnbalancedObject_ShouldThrow()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonUnbalancedObject));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
 
             var x = Assert.ThrowsAny<JsonException>(() =>
             {
@@ -119,7 +119,7 @@ namespace Tests
         public void UnbalancedArray_ShouldThrow()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonUnbalancedArray));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
 
             Assert.ThrowsAny<JsonException>(() =>
             {
@@ -134,7 +134,7 @@ namespace Tests
         public void SmallObject_ShouldContainsAllTokens()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonSmallObject));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
             var tokens = jsonReader.Values().Select(x => x.TokenType).ToList();
 
             Assert.Equal([
@@ -153,7 +153,7 @@ namespace Tests
         public void SmallArray_ShouldContainsAllTokens()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonSmallArray));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
             var tokens = jsonReader.Values().Select(x => x.TokenType).ToList();
 
             Assert.Equal([
@@ -170,8 +170,8 @@ namespace Tests
         public void JsonArray_ShouldContainsValidStringTypes()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
-            var jsonReader = new JsonReader(stream, 10);
-            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.String).Select(v => v.Value.ToString()).ToList();
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.String).Select(v => v.Value?.ToString()).ToList();
 
             Assert.Equal(["2019-08-01T00:00:00-07:00", "Hot", "2019-08-01T00:00:00-07:00", "Hot"], tokens);
         }
@@ -180,7 +180,7 @@ namespace Tests
         public void JsonArray_ShouldContainsValidNumberTypes()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
             var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.Number).Select(v => v.Value.Deserialize<double>()).ToList();
 
             Assert.Equal([25, 20, -10.5, 60, 20, 25, 20, -10, 60, 20], tokens);
@@ -190,7 +190,7 @@ namespace Tests
         public void JsonArray_ShouldContainsValidBooleanTypes()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
-            var jsonReader = new JsonReader(stream, 10);
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
             var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.False || x.TokenType == JsonTokenType.True).Select(v => v.Value.Deserialize<bool>()).ToList();
 
             Assert.Equal([true, false], tokens);

--- a/Tests/JsonReader_Values_Tests.cs
+++ b/Tests/JsonReader_Values_Tests.cs
@@ -1,0 +1,199 @@
+using JsonExtensions;
+using System.Text;
+using System.Text.Json;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    public class JsonReader_Values_Tests
+    {
+        private const string jsonInvalid =
+            """
+            {
+                "a":::::::,,,,,,
+            }
+            """;
+
+        private const string jsonUnbalancedObject =
+            """
+            {
+                "a": 12,
+                "b": 12,
+                "c": 12
+            """;
+
+        private const string jsonUnbalancedArray =
+            """
+            [10,20,30
+            """;
+
+        private const string jsonSmallObject = 
+            """
+                                                                                                {
+                "a": 12,
+                "b": 12,
+                "c": 12
+            }
+            """;
+
+        private const string jsonSmallArray = """[12,12,12]""";
+
+        private const string jsonArray =
+            """
+            [{
+                "Date": "2019-08-01T00:00:00-07:00",
+                "Temperature": 25,
+                "TemperatureRanges": {
+                    "Cold": { "High": 20, "Low": -10.5 },
+                    "Hot": { "High": 60, "Low": 20 }
+                },
+                "Summary": "Hot",
+                "IsHot": true
+            }, 
+            {
+                "Date": "2019-08-01T00:00:00-07:00",
+                "Temperature": 25,
+                "TemperatureRanges": {
+                    "Cold": { "High": 20, "Low": -10 },
+                    "Hot": { "High": 60, "Low": 20 }
+                },
+                "Summary": "Hot",
+                "IsHot": false
+            }]
+            """;
+
+        private readonly ITestOutputHelper output;
+
+        public JsonReader_Values_Tests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void LargeTokenGap_ShouldThrow()
+        {
+            var largeGapJson = $"{{ \"a\": {new String(' ', 2 * 1024 * 1024)}10 }}";
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(largeGapJson));
+            var jsonReader = new JsonReader(stream, 10);
+
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                foreach(var v in jsonReader.Values())
+                {
+                    output.WriteLine($"{v.TokenType}");
+                }
+            });
+        }
+
+        [Fact]
+        public void InvalidJson_ShouldThrow()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonInvalid));
+            var jsonReader = new JsonReader(stream, 10);
+
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                foreach(var v in jsonReader.Values())
+                {
+                    output.WriteLine($"{v.TokenType}");
+                }
+            });
+        }
+
+        [Fact]
+        public void UnbalancedObject_ShouldThrow()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonUnbalancedObject));
+            var jsonReader = new JsonReader(stream, 10);
+
+            var x = Assert.ThrowsAny<JsonException>(() =>
+            {
+                foreach(var v in jsonReader.Values())
+                {
+                    output.WriteLine($"{v.TokenType}");
+                }
+            });
+        }
+
+        [Fact]
+        public void UnbalancedArray_ShouldThrow()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonUnbalancedArray));
+            var jsonReader = new JsonReader(stream, 10);
+
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                foreach(var v in jsonReader.Values())
+                {
+                    output.WriteLine($"{v.TokenType}");
+                }
+            });
+        }
+
+        [Fact]
+        public void SmallObject_ShouldContainsAllTokens()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonSmallObject));
+            var jsonReader = new JsonReader(stream, 10);
+            var tokens = jsonReader.Values().Select(x => x.TokenType).ToList();
+
+            Assert.Equal([
+                JsonTokenType.StartObject,
+                JsonTokenType.PropertyName,
+                JsonTokenType.Number,
+                JsonTokenType.PropertyName,
+                JsonTokenType.Number,
+                JsonTokenType.PropertyName,
+                JsonTokenType.Number,
+                JsonTokenType.EndObject],
+             tokens);
+        }
+
+        [Fact]
+        public void SmallArray_ShouldContainsAllTokens()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonSmallArray));
+            var jsonReader = new JsonReader(stream, 10);
+            var tokens = jsonReader.Values().Select(x => x.TokenType).ToList();
+
+            Assert.Equal([
+                JsonTokenType.StartArray,
+                JsonTokenType.Number,
+                JsonTokenType.Number,
+                JsonTokenType.Number,
+                JsonTokenType.EndArray],
+             tokens);
+        }
+
+
+        [Fact]
+        public void JsonArray_ShouldContainsValidStringTypes()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
+            var jsonReader = new JsonReader(stream, 10);
+            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.String).Select(v => v.Value.ToString()).ToList();
+
+            Assert.Equal(["2019-08-01T00:00:00-07:00", "Hot", "2019-08-01T00:00:00-07:00", "Hot"], tokens);
+        }
+
+        [Fact]
+        public void JsonArray_ShouldContainsValidNumberTypes()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
+            var jsonReader = new JsonReader(stream, 10);
+            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.Number).Select(v => v.Value.Deserialize<double>()).ToList();
+
+            Assert.Equal([25, 20, -10.5, 60, 20, 25, 20, -10, 60, 20], tokens);
+        }
+
+        [Fact]
+        public void JsonArray_ShouldContainsValidBooleanTypes()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonArray));
+            var jsonReader = new JsonReader(stream, 10);
+            var tokens = jsonReader.Values().Where(x => x.TokenType == JsonTokenType.False || x.TokenType == JsonTokenType.True).Select(v => v.Value.Deserialize<bool>()).ToList();
+
+            Assert.Equal([true, false], tokens);
+        }
+    }
+}


### PR DESCRIPTION
Renaming `Read()` method to `Values()` and introduce a `Read()` method that will return true / false and a property `Current` to get the current retrieved value.

``` cs 
while (jsonReader.Read())
{
    
    if (jsonReader.Current.TokenType == JsonTokenType.PropertyName)
    {
        var prop = jsonReader.Current.Name;
        jsonReader.Skip();
        var value = jsonReader.Current.Value;
        Console.WriteLine($"{prop}: {value}");
    }
}
```
But I still want to be able to iterate, of course:

``` cs
foreach (var prop in jsonReader.Values())
{

}
```

Having an instance with a "state" will also allow us to reuse the same instance in multiple places:
``` cs
while (jsonReader.Read() && jsonReader.Current.PropertyName != "A")
{
 .. // DO stuff
}

.... // Do stuff

// continue to iterate
jsonReader.Read();

``` 

Combining both `Values()` and `Read()` can lead to this (love it !)

``` cs
using var jsonReader = new JsonReader(stream);

// select a token
jsonReader.Values().First(jr => jr.Name == "IsHot");

// skip to value
jsonReader.Skip();

// asert Current
Assert.Equal(true, jsonReader.Current.Value?.GetValue<Boolean>());

```


But doing this will introduce some state variables and will need to implement `IDisposable`.
