### PR TITLE
Some Optimizations

### DIFF
--- a/JsonExtensions/AssemblyInfo.cs
+++ b/JsonExtensions/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tests")]

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Text;
@@ -277,7 +277,7 @@ namespace JsonExtensions
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
                 return null;
 
-            var str = utf8Encoding.GetString(this.Value.ToArray());
+            var str = utf8Encoding.GetString(this.Value.Span);
 
             return Regex.Unescape(str);
         }
@@ -291,7 +291,7 @@ namespace JsonExtensions
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
                 return null;
 
-            var str = utf8Encoding.GetString(this.Value.ToArray());
+            var str = utf8Encoding.GetString(this.Value.Span);
 
             return str;
         }

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Text;
@@ -485,7 +485,7 @@ namespace JsonExtensions
 
         public JsonReaderValue() { }
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             var sb = new StringBuilder($"Type: {this.TokenType} - Depth: {this.Depth}");
 

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -269,7 +269,11 @@ namespace JsonExtensions
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
                 return null;
 
+#if NET6_0_OR_GREATER
             var str = utf8Encoding.GetString(this.Value.Span);
+#else   
+            var str = utf8Encoding.GetString(this.Value.ToArray());
+#endif
 
             return JsonEncodedText.Encode(str).ToString();
         }
@@ -285,7 +289,11 @@ namespace JsonExtensions
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
                 return null;
 
+#if NET6_0_OR_GREATER
             var str = utf8Encoding.GetString(this.Value.Span);
+#else   
+            var str = utf8Encoding.GetString(this.Value.ToArray());
+#endif
 
             return str;
         }

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Text;
@@ -490,10 +490,10 @@ namespace JsonExtensions
             var sb = new StringBuilder($"Type: {this.TokenType} - Depth: {this.Depth}");
 
             if (this.TokenType == JsonTokenType.PropertyName)
-                sb.Append($" - Property: {this.Value}");
+                sb.Append(" - Property: ").Append(this.Value);
 
             if (this.Value != null)
-                sb.Append($" - Value: {this.Value}");
+                sb.Append(" - Value: ").Append(this.Value);
 
             return sb.ToString();
         }

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -16,9 +16,6 @@ namespace JsonExtensions
         /// </summary>
         public Stream Stream { get; }
 
-        // buffer size
-        private readonly int bufferSize;
-        private readonly JsonReaderOptions jsonReaderOptions;
         private const int MaxTokenGap = 1024 * 1024;
 
         /// <summary>
@@ -30,8 +27,6 @@ namespace JsonExtensions
         public JsonReader(Stream stream, JsonReaderOptions jsonReaderOptions = default, int bufferSize = 1024)
         {
             this.Stream = stream;
-            this.bufferSize = bufferSize;
-            this.jsonReaderOptions = jsonReaderOptions;
 
             if (!this.Stream.CanRead)
                 throw new Exception("Stream is not readable");
@@ -61,7 +56,6 @@ namespace JsonExtensions
 
         // state object used internally by Utf8JsonReader
         private JsonReaderState currentState;
-        private JsonReaderState prevState;
 
         // bytes consumed by Utf8JsonReader each time it reads a token
         private int bytesConsumed;

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -2,7 +2,6 @@ using System.Buffers.Text;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 
 namespace JsonExtensions
 {
@@ -272,7 +271,7 @@ namespace JsonExtensions
 
             var str = utf8Encoding.GetString(this.Value.Span);
 
-            return Regex.Unescape(str);
+            return JsonEncodedText.Encode(str).ToString();
         }
 
         public string? ReadAsEscapedString()

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -142,7 +142,14 @@ namespace JsonExtensions
                     this.hasMore = true;
                     this.TokenType = reader.TokenType;
                     this.Depth = reader.CurrentDepth;
-                    this.Value = new ReadOnlyMemory<byte>(reader.ValueSpan.ToArray());
+                    if (reader.TokenType == JsonTokenType.String || reader.TokenType == JsonTokenType.PropertyName)
+                    {
+                        this.Value = reader.ValueSpan.ToArray();
+                    }
+                    else
+                    {
+                        this.Value = new ReadOnlyMemory<byte>(this.buffer, this.dataPos + (int)reader.TokenStartIndex, reader.ValueSpan.Length);
+                    }
                     return true;
                 }
 

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -202,16 +202,27 @@ namespace JsonExtensions
             while (this.Read())
             {
                 JsonReaderValue jsonReaderValue = new() { TokenType = this.TokenType, Depth = this.Depth };
-                if (this.TokenType == JsonTokenType.PropertyName)
-                    jsonReaderValue.Value = JsonValue.Create(this.GetString());
-                else if (this.TokenType == JsonTokenType.Null || this.TokenType == JsonTokenType.None)
-                    jsonReaderValue.Value = null;
-                else if (this.TokenType == JsonTokenType.String)
-                    jsonReaderValue.Value = JsonValue.Create(this.GetString());
-                else if (this.TokenType == JsonTokenType.False || this.TokenType == JsonTokenType.True)
-                    jsonReaderValue.Value = JsonValue.Create(this.GetBoolean());
-                else if (this.TokenType == JsonTokenType.Number)
-                    jsonReaderValue.Value = JsonValue.Create(this.GetDouble());
+
+                switch (this.TokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                        jsonReaderValue.Value = JsonValue.Create(this.GetString());
+                        break;
+                    case JsonTokenType.Null:
+                    case JsonTokenType.None:
+                        jsonReaderValue.Value = null;
+                        break;
+                    case JsonTokenType.String:
+                        jsonReaderValue.Value = JsonValue.Create(this.GetString());
+                        break;
+                    case JsonTokenType.False:
+                    case JsonTokenType.True:
+                        jsonReaderValue.Value = JsonValue.Create(this.GetBoolean());
+                        break;
+                    case JsonTokenType.Number:
+                        jsonReaderValue.Value = JsonValue.Create(this.GetDouble());
+                        break;
+                }
 
                 yield return jsonReaderValue;
             }
@@ -222,24 +233,29 @@ namespace JsonExtensions
         /// </summary>
         public bool Skip()
         {
-            if (this.TokenType == JsonTokenType.PropertyName)
-                return this.Read();
-
-            if (this.TokenType == JsonTokenType.StartObject || this.TokenType == JsonTokenType.StartArray)
+            switch (this.TokenType)
             {
-                int depth = this.Depth;
-                do
-                {
-                    bool hasRead = this.Read();
+                case JsonTokenType.PropertyName:
+                    return this.Read();
+                case JsonTokenType.StartObject:
+                case JsonTokenType.StartArray:
+                    {
+                        int depth = this.Depth;
+                        do
+                        {
+                            bool hasRead = this.Read();
 
-                    if (!hasRead)
-                        return false;
-                }
-                while (depth < this.Depth);
+                            if (!hasRead)
+                                return false;
+                        }
+                        while (depth < this.Depth);
 
-                return true;
+                        return true;
+                    }
+
+                default:
+                    return false;
             }
-            return false;
         }
 
         protected virtual void Dispose(bool disposing)
@@ -515,12 +531,15 @@ namespace JsonExtensions
 
         public bool? GetBoolean()
         {
-            if (this.TokenType == JsonTokenType.True)
-                return true;
-            else if (this.TokenType == JsonTokenType.False)
-                return false;
-            else
-                return null;
+            switch (this.TokenType)
+            {
+                case JsonTokenType.True:
+                    return true;
+                case JsonTokenType.False:
+                    return false;
+                default:
+                    return null;
+            }
         }
 
         //public byte[] GetBytesFromBase64()

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -8,10 +8,8 @@ using System.Text.RegularExpressions;
 
 namespace JsonExtensions
 {
-
     public class JsonReader : IDisposable
     {
-
         // encoding used to convert bytes to string
         private static readonly UTF8Encoding utf8Encoding = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
@@ -75,7 +73,6 @@ namespace JsonExtensions
 
         private bool disposedValue;
 
-
         ///// <summary>
         ///// Current value
         ///// </summary>
@@ -95,8 +92,6 @@ namespace JsonExtensions
         /// Gets the current depth
         /// </summary>
         public int Depth { get; private set; } = 0;
-
-
 
         /// <summary>
         /// Read the next value. Can be any TokenType
@@ -266,12 +261,12 @@ namespace JsonExtensions
             GC.SuppressFinalize(this);
         }
 
-
         public string? ReadAsString()
         {
             this.Read();
             return this.GetString();
         }
+
         public string? GetString()
         {
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -149,7 +149,7 @@ namespace JsonExtensions
                     this.hasMore = true;
                     this.TokenType = reader.TokenType;
                     this.Depth = reader.CurrentDepth;
-                    if (reader.TokenType == JsonTokenType.String || reader.TokenType == JsonTokenType.PropertyName)
+                    if (reader.TokenType is JsonTokenType.String or JsonTokenType.PropertyName)
                     {
                         this.Value = reader.ValueSpan.ToArray();
                     }

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -228,7 +228,6 @@ namespace JsonExtensions
             return false;
         }
 
-
         protected virtual void Dispose(bool disposing)
         {
             if (!this.disposedValue)
@@ -274,11 +273,13 @@ namespace JsonExtensions
 
             return Regex.Unescape(str);
         }
+
         public string? ReadAsEscapedString()
         {
             this.Read();
             return this.GetEscapedString();
         }
+
         public string? GetEscapedString()
         {
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
@@ -288,11 +289,13 @@ namespace JsonExtensions
 
             return str;
         }
+
         public Guid? ReadAsGuid()
         {
             this.Read();
             return this.GetGuid();
         }
+
         public Guid? GetGuid()
         {
             if (this.TokenType != JsonTokenType.String)
@@ -303,11 +306,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse double");
         }
+
         public TimeSpan? ReadAsTimeSpan()
         {
             this.Read();
             return this.GetTimeSpan();
         }
+
         public TimeSpan? GetTimeSpan()
         {
             if (this.TokenType != JsonTokenType.String)
@@ -318,11 +323,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse TimeSpan");
         }
+
         public DateTimeOffset? ReadAsDateTimeOffset()
         {
             this.Read();
             return this.GetDateTimeOffset();
         }
+
         public DateTimeOffset? GetDateTimeOffset()
         {
             if (this.TokenType != JsonTokenType.String)
@@ -333,11 +340,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse DateTimeOffset");
         }
+
         public DateTime? ReadAsDateTime()
         {
             this.Read();
             return this.GetDateTime();
         }
+
         public DateTime? GetDateTime()
         {
             if (this.TokenType != JsonTokenType.String)
@@ -348,11 +357,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse GetDateTime");
         }
+
         public double? ReadAsDouble()
         {
             this.Read();
             return this.GetDouble();
         }
+
         public double? GetDouble()
         {
             if (this.TokenType != JsonTokenType.Number)
@@ -363,11 +374,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse double");
         }
+
         public decimal? ReadAsDecimal()
         {
             this.Read();
             return this.GetDecimal();
         }
+
         public decimal? GetDecimal()
         {
             if (this.TokenType != JsonTokenType.Number)
@@ -378,11 +391,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse decimal");
         }
+
         public float? ReadAsSingle()
         {
             this.Read();
             return this.GetSingle();
         }
+
         public float? GetSingle()
         {
             if (this.TokenType != JsonTokenType.Number)
@@ -393,11 +408,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse float");
         }
+
         public long? ReadAsInt64()
         {
             this.Read();
             return this.GetInt64();
         }
+
         public long? GetInt64()
         {
             if (this.TokenType != JsonTokenType.Number)
@@ -408,11 +425,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse long");
         }
+
         public int? ReadAsInt32()
         {
             this.Read();
             return this.GetInt32();
         }
+
         public int? GetInt32()
         {
             if (this.TokenType != JsonTokenType.Number)
@@ -423,11 +442,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse int");
         }
+
         public short? ReadAsInt16()
         {
             this.Read();
             return this.GetInt16();
         }
+
         public short? GetInt16()
         {
             if (this.TokenType != JsonTokenType.Number)
@@ -438,11 +459,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse short");
         }
+
         public byte? ReadAsByte()
         {
             this.Read();
             return this.GetByte();
         }
+
         public byte? GetByte()
         {
             if (this.TokenType != JsonTokenType.Number)
@@ -453,11 +476,13 @@ namespace JsonExtensions
 
             throw new FormatException("Can't parse byte");
         }
+
         public bool? ReadAsBoolean()
         {
             this.Read();
             return this.GetBoolean();
         }
+
         public bool? GetBoolean()
         {
             if (this.TokenType == JsonTokenType.True)
@@ -472,7 +497,6 @@ namespace JsonExtensions
         //{
         //    return null;
         //}
-
     }
 
     public struct JsonReaderValue

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -1,6 +1,4 @@
-using System.Buffers;
 using System.Buffers.Text;
-using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -313,7 +313,33 @@ namespace JsonExtensions
             var str = utf8Encoding.GetString(this.Value.ToArray());
 #endif
 
-            return JsonEncodedText.Encode(str).ToString();
+            StringBuilder sb = new(str.Length);
+            for (int i = 0; i < str.Length; i++)
+            {
+                if (str[i] == '\\' && i < str.Length - 1)
+                {
+                    char nextChar = str[i + 1];
+                    switch (nextChar)
+                    {
+                        case 'n': sb.Append('\n'); break;
+                        case 'r': sb.Append('\r'); break;
+                        case 't': sb.Append('\t'); break;
+                        case 'b': sb.Append('\b'); break;
+                        case 'f': sb.Append('\f'); break;
+                        case '\\': sb.Append('\\'); break;
+                        case '/': sb.Append('/'); break;
+                        case '\"': sb.Append('\"'); break;
+                        default: sb.Append('\\').Append(nextChar); break;
+                    }
+                    i++; // Skip the next character
+                }
+                else
+                {
+                    sb.Append(str[i]);
+                }
+            }
+
+            return sb.ToString();
         }
 
         public string? ReadAsEscapedString()

--- a/Tests/JsonReader_Read_Tests.cs
+++ b/Tests/JsonReader_Read_Tests.cs
@@ -216,9 +216,40 @@ namespace Tests
 
             // asert Current
             Assert.False(jsonReader.ReadAsBoolean());
-
-
         }
 
+        [Fact]
+        public void PropertyNameToken_ShouldHaveCorrectValue()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonSmallObject));
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.StartObject, jsonReader.TokenType);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.PropertyName, jsonReader.TokenType);
+            Assert.Equal("a", jsonReader.GetString());
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.Number, jsonReader.TokenType);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.PropertyName, jsonReader.TokenType);
+            Assert.Equal("b", jsonReader.GetString());
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.Number, jsonReader.TokenType);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.PropertyName, jsonReader.TokenType);
+            Assert.Equal("c", jsonReader.GetString());
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.Number, jsonReader.TokenType);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.EndObject, jsonReader.TokenType);
+        }
     }
 }

--- a/Tests/JsonReader_Read_Tests.cs
+++ b/Tests/JsonReader_Read_Tests.cs
@@ -194,7 +194,37 @@ namespace Tests
             Assert.Equal("Hot", jsonReader.GetString());
         }
 
+        [Fact]
+        public void ReadAsEscapedString_ShouldReturnEscapedString()
+        {
+            const string jsonEscapedString = "\"Hello\\nWorld\"";
 
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
+            var result = jsonReader.GetEscapedString();
+
+            Assert.Equal("Hello\\nWorld", result);
+        }
+
+        [Fact]
+        public void ReadAsString_ShouldReturnUnescapedString()
+        {
+            const string jsonEscapedString = "\"Hello\\nWorld\"";
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
+            var result = jsonReader.GetString();
+
+            const string jsonUnescapedString = "Hello\nWorld";
+
+            Assert.Equal(jsonUnescapedString, result);
+        }
 
         [Fact]
         public void JsonArray_ShouldContainsValidBooleans()

--- a/Tests/JsonReader_Read_Tests.cs
+++ b/Tests/JsonReader_Read_Tests.cs
@@ -197,7 +197,10 @@ namespace Tests
         [Fact]
         public void ReadAsEscapedString_ShouldReturnEscapedString()
         {
-            const string jsonEscapedString = "\"Hello\\nWorld\"";
+            const string jsonEscapedString = 
+                """
+                "Hello\nWorld"
+                """;
 
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
             var jsonReader = new JsonReader(stream, bufferSize: 10);
@@ -206,13 +209,18 @@ namespace Tests
             Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
             var result = jsonReader.GetEscapedString();
 
-            Assert.Equal("Hello\\nWorld", result);
+            const string escapedString = """Hello\nWorld""";
+
+            Assert.Equal(escapedString, result);
         }
 
         [Fact]
         public void ReadAsString_ShouldReturnUnescapedString()
         {
-            const string jsonEscapedString = "\"Hello\\nWorld\"";
+            const string jsonEscapedString = 
+                """
+                "Hello\nWorld"
+                """;
 
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
             var jsonReader = new JsonReader(stream, bufferSize: 10);
@@ -221,9 +229,9 @@ namespace Tests
             Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
             var result = jsonReader.GetString();
 
-            const string jsonUnescapedString = "Hello\nWorld";
+            const string unescapedString = "Hello\nWorld";
 
-            Assert.Equal(jsonUnescapedString, result);
+            Assert.Equal(unescapedString, result);
         }
 
         [Fact]

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -10,10 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Probably best to read them commit by commit. Take what you like.

The complex part is the JSON (un)escaping. Switched to custom unescaping because Regex is beefy and unneeded. And actually Regex.Unescape() will unescape a broader range of escape sequences than the JSON spec allows.

There is an optional shared buffer via ArrayPool that I have turned off by default. Keeping old buffer data in memory may not be something that everyone wants.