### PR TITLE
Custom unescape

### DIFF
--- a/Tests/JsonReader_Read_Tests.cs
+++ b/Tests/JsonReader_Read_Tests.cs
@@ -216,9 +216,38 @@ namespace Tests
 
             // asert Current
             Assert.False(jsonReader.ReadAsBoolean());
-
-
         }
 
+        [Fact]
+        public void ReadAsEscapedString_ShouldReturnEscapedString()
+        {
+            const string jsonEscapedString = "\"Hello\\nWorld\"";
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
+            var result = jsonReader.GetEscapedString();
+
+            Assert.Equal("Hello\\nWorld", result);
+        }
+
+        [Fact]
+        public void ReadAsString_ShouldReturnUnescapedString()
+        {
+            const string jsonEscapedString = "\"Hello\\nWorld\"";
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
+            var result = jsonReader.GetString();
+
+            const string jsonUnescapedString = "Hello\nWorld";
+
+            Assert.Equal(jsonUnescapedString, result);
+        }
     }
 }


### PR DESCRIPTION
This change reduces allocations. Binary size could also be reduced by 139 KB with trimming because the RegularExpressions reference isn't needed.

Added unit tests to ensure correctness.

Unit tests pass both before and after adding the custom unescaping.
 
Before:

| Method | Mean     | Error    | StdDev   | Median   | Gen0       | Allocated |
|------- |---------:|---------:|---------:|---------:|-----------:|----------:|
| Read   | 21.70 ms | 0.270 ms | 1.108 ms | 21.49 ms |  3000.0000 |  27.49 MB |
| Values | 57.67 ms | 0.706 ms | 2.982 ms | 57.67 ms | 15000.0000 | 140.59 MB |


After:

| Method | Mean     | Error    | StdDev   | Median   | Gen0       | Allocated |
|------- |---------:|---------:|---------:|---------:|-----------:|----------:|
| Read   | 21.73 ms | 0.241 ms | 0.989 ms | 21.54 ms |  2000.0000 |  20.02 MB |
| Values | 54.47 ms | 0.609 ms | 2.559 ms | 54.39 ms | 14000.0000 | 133.21 MB |