### PR TITLE
use span

### DIFF
--- a/JsonExtensions/JsonReader.cs
+++ b/JsonExtensions/JsonReader.cs
@@ -277,7 +277,11 @@ namespace JsonExtensions
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
                 return null;
 
+#if NET6_0_OR_GREATER
+            var str = utf8Encoding.GetString(this.Value.Span);
+#else   
             var str = utf8Encoding.GetString(this.Value.ToArray());
+#endif
 
             return Regex.Unescape(str);
         }
@@ -291,7 +295,11 @@ namespace JsonExtensions
             if (this.TokenType != JsonTokenType.PropertyName && this.TokenType != JsonTokenType.String)
                 return null;
 
+#if NET6_0_OR_GREATER
+            var str = utf8Encoding.GetString(this.Value.Span);
+#else   
             var str = utf8Encoding.GetString(this.Value.ToArray());
+#endif
 
             return str;
         }

--- a/Tests/JsonReader_Read_Tests.cs
+++ b/Tests/JsonReader_Read_Tests.cs
@@ -216,9 +216,38 @@ namespace Tests
 
             // asert Current
             Assert.False(jsonReader.ReadAsBoolean());
-
-
         }
 
+        [Fact]
+        public void ReadAsEscapedString_ShouldReturnEscapedString()
+        {
+            const string jsonEscapedString = "\"Hello\\nWorld\"";
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
+            var result = jsonReader.GetEscapedString();
+
+            Assert.Equal("Hello\\nWorld", result);
+        }
+
+        [Fact]
+        public void ReadAsString_ShouldReturnUnescapedString()
+        {
+            const string jsonEscapedString = "\"Hello\\n\\u003EWorld\"";
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonEscapedString));
+            var jsonReader = new JsonReader(stream, bufferSize: 10);
+
+            jsonReader.Read();
+            Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
+            var result = jsonReader.GetString();
+
+            const string jsonUnescapedString = "Hello\n>World";
+
+            Assert.Equal(jsonUnescapedString, result);
+        }
     }
 }


### PR DESCRIPTION
Reduces allocations. Added some tests.

Before:

| Method | Mean     | Error    | StdDev   | Gen0       | Allocated |
|------- |---------:|---------:|---------:|-----------:|----------:|
| Read   | 20.49 ms | 0.313 ms | 1.276 ms |  3000.0000 |  27.49 MB |
| Values | 54.52 ms | 0.496 ms | 2.079 ms | 15000.0000 | 140.59 MB |

After:

| Method | Mean     | Error    | StdDev   | Gen0       | Allocated |
|------- |---------:|---------:|---------:|-----------:|----------:|
| Read   | 19.04 ms | 0.261 ms | 1.081 ms |  2000.0000 |  20.01 MB |
| Values | 54.25 ms | 0.666 ms | 2.805 ms | 14000.0000 | 133.11 MB |



-----

If I change the Read benchmark to use `GetEscapedString()` instead of `GetString()` we see the following results




Before:

| Method | Mean     | Error    | StdDev   | Gen0       | Allocated |
|------- |---------:|---------:|---------:|-----------:|----------:|
| Read   | 20.21 ms | 0.257 ms | 1.047 ms |  3000.0000 |  27.49 MB |

After:

| Method | Mean     | Error    | StdDev   | Gen0       | Allocated |
|------- |---------:|---------:|---------:|-----------:|----------:|
| Read   | 18.87 ms | 0.269 ms | 1.108 ms |  2000.0000 |  20.01 MB |
