### PR TITLE
add comparisons

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="Utf8JsonAsyncStreamReader" Version="1.0.0" />
+    <PackageReference Include="Utf8JsonStreamReader" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Benchmarks/JsonReaderBenchmarks.cs
+++ b/Benchmarks/JsonReaderBenchmarks.cs
@@ -32,6 +32,7 @@ public class JsonReaderBenchmarks
     {
         _fileStream.Dispose();
         _jsonReader?.Dispose();
+        _jsonStreamAsyncReader?.Dispose(true);
     }
 
     [IterationCleanup]

--- a/Benchmarks/JsonReaderBenchmarks.cs
+++ b/Benchmarks/JsonReaderBenchmarks.cs
@@ -2,13 +2,18 @@ namespace JsonExtensions.Benchmarks;
 
 using BenchmarkDotNet.Attributes;
 using System.Text.Json;
+using System.Text.Json.Stream;
+using Wololo.Text.Json;
 
 [MemoryDiagnoser]
 [Config(typeof(AntiVirusFriendlyConfig))]
 public class JsonReaderBenchmarks
 {
     private JsonReader? _jsonReader;
-    private FileStream? _fileStream;
+    private Utf8JsonStreamReader? _jsonStreamReader;
+    private Utf8JsonAsyncStreamReader? _jsonStreamAsyncReader;
+
+    private FileStream _fileStream = null!;
 
     private const int IterationsNum = 100;
 
@@ -16,28 +21,30 @@ public class JsonReaderBenchmarks
     public void Setup()
     {
         string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "dummy-data.json");
-        _fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
-        _jsonReader = new JsonReader(_fileStream);
+        _fileStream = new(path, FileMode.Open, FileAccess.Read);
+        _jsonReader = new(_fileStream);
+        _jsonStreamReader = new();
+        _jsonStreamAsyncReader = new(_fileStream);
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
-        _fileStream?.Dispose();
+        _fileStream.Dispose();
         _jsonReader?.Dispose();
     }
 
     [IterationCleanup]
     public void IterationCleanup()
     {
-        _fileStream?.Seek(0, SeekOrigin.Begin);
+        _fileStream.Seek(0, SeekOrigin.Begin);
         _jsonReader?.Dispose();
         _jsonReader = new JsonReader(_fileStream);
     }
 
     [Benchmark]
     [IterationCount(IterationsNum)]
-    public void Read()
+    public void ReadMimetis()
     {
         ArgumentNullException.ThrowIfNull(_jsonReader);
 
@@ -45,11 +52,12 @@ public class JsonReaderBenchmarks
 
         while (_jsonReader.Read())
         {
-            var tokenString = _jsonReader.GetString();
-
-            if (_jsonReader.TokenType == JsonTokenType.PropertyName)
+            switch (_jsonReader.TokenType)
             {
-                // TODO: Perform some operation
+                case JsonTokenType.PropertyName:
+                case JsonTokenType.String:
+                    var tokenString = _jsonReader.GetString();
+                    break;
             }
 
             count++;
@@ -58,10 +66,9 @@ public class JsonReaderBenchmarks
         Console.WriteLine("Count: " + count);
     }
 
-    
     [Benchmark]
     [IterationCount(IterationsNum)]
-    public void Values()
+    public void ValuesMimetis()
     {
         ArgumentNullException.ThrowIfNull(_jsonReader);
 
@@ -73,7 +80,57 @@ public class JsonReaderBenchmarks
 
             if (value.TokenType == JsonTokenType.PropertyName)
             {
-                // TODO: Perform some operation
+                // Console.WriteLine("PropertyName Found");
+            }
+
+            count++;
+        }
+
+        Console.WriteLine("Count: " + count);
+    }
+
+    [Benchmark]
+    [IterationCount(IterationsNum)]
+    public async Task ReadHarrtell()
+    {
+        ArgumentNullException.ThrowIfNull(_jsonStreamReader);
+
+        int count = 0;
+
+        void CountTokens(ref Utf8JsonReader reader)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.PropertyName:
+                case JsonTokenType.String:
+                    var tokenString = reader.GetString();
+                    break;
+            }
+
+            count++;
+        }
+
+        await _jsonStreamReader.ReadAsync(_fileStream, CountTokens);
+
+        Console.WriteLine("Count: " + count);
+    }
+
+    [Benchmark]
+    [IterationCount(IterationsNum)]
+    public async Task ReadGraGra()
+    {
+        ArgumentNullException.ThrowIfNull(_jsonStreamAsyncReader);
+
+        int count = 0;
+
+        while (await _jsonStreamAsyncReader.ReadAsync())
+        {
+            switch (_jsonStreamAsyncReader.TokenType)
+            {
+                case JsonTokenType.PropertyName:
+                case JsonTokenType.String:
+                    var tokenString = _jsonStreamAsyncReader.GetString();
+                    break;
             }
 
             count++;

--- a/Benchmarks/JsonReaderBenchmarks.cs
+++ b/Benchmarks/JsonReaderBenchmarks.cs
@@ -39,8 +39,6 @@ public class JsonReaderBenchmarks
     public void IterationCleanup()
     {
         _fileStream.Seek(0, SeekOrigin.Begin);
-        _jsonReader?.Dispose();
-        _jsonReader = new JsonReader(_fileStream);
     }
 
     [Benchmark]

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,11 +1,16 @@
 ﻿namespace JsonExtensions.Benchmarks;
 
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 public class Program
 {
+#if DEBUG
+    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
+#else
     static void Main(string[] args)
     {
         _ = BenchmarkRunner.Run<JsonReaderBenchmarks>();
     }
+#endif
 }


### PR DESCRIPTION
Here are very basic some comparisons to:

- https://github.com/gragra33/Utf8JsonAsyncStreamReader
- https://github.com/bjornharrtell/Utf8JsonStreamReader/

| Method        | Mean     | Error    | StdDev   | Median   | Allocated |
|-------------- |---------:|---------:|---------:|---------:|----------:|
| ReadMimetis   | 86.04 us | 6.517 us | 27.23 us | 83.40 us |     728 B |
| ValuesMimetis | 72.86 us | 6.507 us | 27.19 us | 67.60 us |    1112 B |
| ReadHarrtell  | 72.80 us | 6.945 us | 28.79 us | 64.65 us |    1152 B |
| ReadGraGra    | 80.94 us | 5.528 us | 22.73 us | 86.90 us |    1064 B |

The author of one of them claims to have noticed dramatic performance differences, but in this very simple benchmark I see modest differences.

https://github.com/bjornharrtell/Utf8JsonStreamReader/issues/10